### PR TITLE
resolve error getViewport 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-pdf-optimization",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Lightweight PDF viewer for optimization",
   "repository": {
     "url": "https://github.com/abcde158308/vue-pdf-optimization.git",

--- a/src/components/VuePdf.js
+++ b/src/components/VuePdf.js
@@ -66,10 +66,10 @@ export default {
         const pageNumber = this.num
         this._page = await this._pdf.getPage(pageNumber)
         const desiredWidth = this.$el.clientWidth
-        const viewport = this._page.getViewport(1)
+        const viewport = this._page.getViewport({ scale: 1 })
 
         const scale = desiredWidth / viewport.width
-        const scaledViewport = this._page.getViewport(scale)
+        const scaledViewport = this._page.getViewport({ scale: scale })
 
         const canvas = this.$refs.canvas
         canvas.height = scaledViewport.height


### PR DESCRIPTION
if using
`.getViewport(1);` it will result
`Failure during downloading PDF file: Error: PDFPageProxy.getViewport is called with obsolete arguments.`

so, from the pdfJS the scale has to be object
`https://mozilla.github.io/pdf.js/examples/`
`.getViewport({ scale: scale, });`

P.S. 
please ignore the version as it's wrongly update as i try to publish for my use